### PR TITLE
CraftingHandler that keeps the saws from being consumed in crafting o…

### DIFF
--- a/src/main/java/com/peffern/wells/CraftingHandler.java
+++ b/src/main/java/com/peffern/wells/CraftingHandler.java
@@ -1,0 +1,63 @@
+package com.peffern.wells;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.PlayerEvent;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+
+import java.util.List;
+
+public class CraftingHandler
+{
+    @SubscribeEvent
+    public void onCrafting (PlayerEvent.ItemCraftedEvent e)
+    {
+        EntityPlayer player = e.player;
+        ItemStack itemstack = e.crafting;
+        Item item = itemstack.getItem();
+        IInventory iinventory = e.craftMatrix;
+
+        if (iinventory != null) {
+
+            if(item == Item.getItemFromBlock(TFCWells.well))
+            {
+                List<ItemStack> saw = OreDictionary.getOres("itemSaw", false);
+                handleItem(player, iinventory, saw);
+            }
+        }
+    }
+
+    public static void handleItem(EntityPlayer entityplayer, IInventory iinventory, List<ItemStack> items)
+    {
+        for (int i = 0; i < iinventory.getSizeInventory(); i++ )
+        {
+            if (iinventory.getStackInSlot(i) == null)
+                continue;
+            for (ItemStack is : items)
+                damageItem(entityplayer, iinventory, i, is.getItem());
+        }
+    }
+
+    public static void damageItem(EntityPlayer entityplayer, IInventory iinventory, int i, Item shiftedindex)
+    {
+        if(iinventory.getStackInSlot(i).getItem() == shiftedindex)
+        {
+            int index = i;
+            ItemStack item = iinventory.getStackInSlot(index).copy();
+            if(item != null)
+            {
+                item.damageItem(1 , entityplayer);
+                if (item.getItemDamage() != 0 || entityplayer.capabilities.isCreativeMode)
+                {
+                    iinventory.setInventorySlotContents(index, item);
+                    iinventory.getStackInSlot(index).stackSize = iinventory.getStackInSlot(index).stackSize + 1;
+                    if(iinventory.getStackInSlot(index).stackSize > 2)
+                        iinventory.getStackInSlot(index).stackSize = 2;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/peffern/wells/TFCWells.java
+++ b/src/main/java/com/peffern/wells/TFCWells.java
@@ -2,6 +2,7 @@ package com.peffern.wells;
 
 import com.bioxx.tfc.api.TFCItems;
 
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.EventHandler;
 import cpw.mods.fml.common.Mod.Instance;
@@ -54,6 +55,8 @@ public class TFCWells
 		
 		//crafting
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(well,1), "ABA","CDC","AEA",'A',"plankWood",'B',"itemSaw",'C',"ingotIron",'D',TFCItems.rope, 'E', TFCItems.woodenBucketEmpty));
+
+		FMLCommonHandler.instance().bus().register(new com.peffern.wells.CraftingHandler());
 
 	}
 	


### PR DESCRIPTION
…f well block. TFC handles these things differently than most mods. Basically this code duplicates the saw and replaces it with one that has less durability. For TNFC we’ve changed the tools to be Item Containers, which is how tools are normally handles so they aren’t consumed, only damaged in crafting.